### PR TITLE
マイページ、購入完了ページのa要素文字色が変わらないように修正

### DIFF
--- a/app/assets/stylesheets/modules/_userInfo.scss
+++ b/app/assets/stylesheets/modules/_userInfo.scss
@@ -119,6 +119,9 @@
               background: linear-gradient(#ffffff, #ececec);
               font-weight: bold;
             }
+            a:visited{
+              color: #646166;
+            }
           }
           &__bottom{
             background-color: #ff59c3;
@@ -138,7 +141,10 @@
                 position: absolute;
                 right: 5px;
                 margin-top: 20px;
-            }
+                }
+                a:visited{
+                  color: white;
+                }
             
           }
         }


### PR DESCRIPTION
#what
マイページの「ログアウト」ボタン・「ショップ詳細」ボタン、購入完了ページの「トップページへ戻る」ボタンの文字色がリンクを踏むと青色に変わってしまうので変わらないように変更

#why
変わらない方が色彩を保てると判断したため